### PR TITLE
fix: resolve tajweed font clipping and add responsive container

### DIFF
--- a/src/view/react/index.tsx
+++ b/src/view/react/index.tsx
@@ -133,33 +133,42 @@ export const OpenQuranView: React.FC<OpenQuranViewProps> = ({
         height,
         background: theme === "dark" ? "#1a1a2e" : "#fafafa",
         position: "relative",
-        overflow: "hidden",
         fontFamily: "system-ui, -apple-system, sans-serif",
         direction: "rtl",
       }}
     >
-      {loading && (
-        <div
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            color: theme === "dark" ? "#fff" : "#333",
-          }}
-        >
-          جاري التحميل...
-        </div>
-      )}
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          position: "relative",
+          overflowY: "hidden",
+          overflowX: "visible",
+        }}
+      >
+        {loading && (
+          <div
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              color: theme === "dark" ? "#fff" : "#333",
+            }}
+          >
+            جاري التحميل...
+          </div>
+        )}
 
-      {!loading && pageLayout && (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            position: "relative",
-          }}
-        >
+        {!loading && pageLayout && (
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              position: "relative",
+              overflow: "visible",
+            }}
+          >
           {pageLayout.lines.map((line) => {
             const isCenteredLine =
               line.isCentered || CENTERED_PAGES_HORIZONTAL_SET.has(currentPage);
@@ -291,6 +300,7 @@ export const OpenQuranView: React.FC<OpenQuranViewProps> = ({
           })}
         </div>
       )}
+      </div>
 
       <NavigationControls
         currentPage={currentPage}

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -13,15 +13,17 @@ const STYLES = `
   :host {
     display: block;
     position: relative;
-    overflow: hidden;
     font-family: system-ui, -apple-system, sans-serif;
     direction: rtl;
+    width: 100%;
+    box-sizing: border-box;
   }
 
   .quran-viewer {
     width: 100%;
     height: 100%;
     position: relative;
+    overflow: hidden;
   }
 
   .quran-loading {
@@ -291,7 +293,8 @@ export class OpenQuranView extends HTMLElement {
       pageHeight: height,
     });
 
-    this.container.style.width = `${width}px`;
+    this.container.style.maxWidth = `${width}px`;
+    this.container.style.width = "100%";
     this.container.style.height = `${height}px`;
     this.updateTheme(theme);
 

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -29,7 +29,8 @@ const STYLES = `
     width: 100%;
     height: 100%;
     position: relative;
-    overflow: hidden;
+    overflow-y: hidden;
+    overflow-x: visible;
   }
 
   .quran-loading {

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -23,6 +23,12 @@ const STYLES = `
     width: 100%;
     height: 100%;
     position: relative;
+  }
+
+  .quran-frame {
+    width: 100%;
+    height: 100%;
+    position: relative;
     overflow: hidden;
   }
 
@@ -38,6 +44,7 @@ const STYLES = `
     width: 100%;
     height: 100%;
     position: relative;
+    overflow: visible;
   }
 
   .quran-line {
@@ -157,8 +164,10 @@ const TEMPLATE = document.createElement("template");
 TEMPLATE.innerHTML = `
   <style>${STYLES}</style>
   <div class="quran-viewer">
-    <div class="quran-loading">جاري التحميل...</div>
-    <div class="quran-content"></div>
+    <div class="quran-frame">
+      <div class="quran-loading">جاري التحميل...</div>
+      <div class="quran-content"></div>
+    </div>
     <div class="quran-nav" style="display: none;">
       <button class="quran-prev" title="السابق">❮</button>
       <button class="quran-page-display"></button>
@@ -280,7 +289,7 @@ export class OpenQuranView extends HTMLElement {
   }
 
   private async initialize(): Promise<void> {
-    const width = parseInt(this.getAttribute("width") || "600", 10);
+    const maxWidth = parseInt(this.getAttribute("width") || "600", 10);
     const height = parseInt(this.getAttribute("height") || "850", 10);
     const theme = (this.getAttribute("theme") || "light") as "light" | "dark";
     const mushafLayout = this.getAttribute(
@@ -288,15 +297,19 @@ export class OpenQuranView extends HTMLElement {
     ) as MushafLayout | null;
     this.layout = mushafLayout || "hafs-v2";
 
-    this.calculator = createLayoutCalculator({
-      pageWidth: width,
-      pageHeight: height,
-    });
-
-    this.container.style.maxWidth = `${width}px`;
+    this.container.style.maxWidth = `${maxWidth}px`;
     this.container.style.width = "100%";
     this.container.style.height = `${height}px`;
     this.updateTheme(theme);
+
+    const renderedWidth =
+      Math.min(maxWidth, this.container.getBoundingClientRect().width) ||
+      maxWidth;
+
+    this.calculator = createLayoutCalculator({
+      pageWidth: renderedWidth,
+      pageHeight: height,
+    });
 
     await this.loadFont();
 


### PR DESCRIPTION
## Summary
- Move `overflow: hidden` from `:host` to `.quran-viewer` to prevent tajweed glyph clipping at component boundaries
- Use `max-width` instead of fixed `width` on the viewer container, allowing it to adapt to available space
- Set `width: 100%` on `:host` and container for responsive behavior
- Add `box-sizing: border-box` on `:host` for consistent sizing

## Problem
When using the **Hafs (QCF V4 with tajweed)** font, extended tajweed glyphs were horizontally clipped because the container used a fixed width and `overflow: hidden` on `:host`.

## Test plan
- [x] All 25 existing tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [ ] Visual verification with tajweed font shows no clipping
- [ ] Component adapts to different container widths

Closes #1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout: content now adapts to a container max width with consistent full‑width behavior.
  * Fixed overflow and scrolling so page content and loading states display without unexpected clipping by introducing a dedicated inner frame.
  * Improved initialization and measurement: layout now uses dynamic rendered width for more consistent page sizing and rendering across viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->