### PR TITLE
refactor: align web view with react view

### DIFF
--- a/playground/vite-typescript/main.ts
+++ b/playground/vite-typescript/main.ts
@@ -30,7 +30,7 @@ const wordInfo = document.getElementById("word-info") as HTMLDivElement;
 goBtn.addEventListener("click", () => {
   const page = parseInt(pageInput.value, 10);
   if (page >= 1 && page <= 604) {
-    viewer.setAttribute("page", String(page));
+    viewer.goToPage(page);
   }
 });
 
@@ -38,21 +38,19 @@ pageInput.addEventListener("keypress", (e: KeyboardEvent) => {
   if (e.key === "Enter") {
     const page = parseInt(pageInput.value, 10);
     if (page >= 1 && page <= 604) {
-      viewer.setAttribute("page", String(page));
+      viewer.goToPage(page);
     }
   }
 });
 
 prevBtn.addEventListener("click", () => {
-  const currentPage = parseInt(viewer.getAttribute("page") || "1", 10);
-  viewer.setAttribute("page", String(Math.max(1, currentPage - 1)));
-  pageInput.value = viewer.getAttribute("page") || "1";
+  viewer.goToPage(viewer.page - 1);
+  pageInput.value = String(viewer.page);
 });
 
 nextBtn.addEventListener("click", () => {
-  const currentPage = parseInt(viewer.getAttribute("page") || "1", 10);
-  viewer.setAttribute("page", String(Math.min(604, currentPage + 1)));
-  pageInput.value = viewer.getAttribute("page") || "1";
+  viewer.goToPage(viewer.page + 1);
+  pageInput.value = String(viewer.page);
 });
 
 themeSelect.addEventListener("change", () => {

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -13,15 +13,17 @@ const STYLES = `
   :host {
     display: block;
     position: relative;
-    overflow: hidden;
     font-family: system-ui, -apple-system, sans-serif;
     direction: rtl;
+    width: 100%;
+    box-sizing: border-box;
   }
 
   .quran-viewer {
     width: 100%;
     height: 100%;
     position: relative;
+    overflow: hidden;
   }
 
   .quran-loading {
@@ -291,7 +293,8 @@ export class OpenQuranView extends HTMLElement {
       pageHeight: height,
     });
 
-    this.container.style.width = `${width}px`;
+    this.container.style.maxWidth = `${width}px`;
+    this.container.style.width = "100%";
     this.container.style.height = `${height}px`;
     this.updateTheme(theme);
 

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -30,6 +30,12 @@ const STYLES = `
     width: 100%;
     height: 100%;
     position: relative;
+  }
+
+  .quran-frame {
+    width: 100%;
+    height: 100%;
+    position: relative;
     overflow: hidden;
   }
 
@@ -45,6 +51,7 @@ const STYLES = `
     width: 100%;
     height: 100%;
     position: relative;
+    overflow: visible;
   }
 
   .quran-line {
@@ -164,8 +171,10 @@ const TEMPLATE = document.createElement("template");
 TEMPLATE.innerHTML = `
   <style>${STYLES}</style>
   <div class="quran-viewer">
-    <div class="quran-loading">جاري التحميل...</div>
-    <div class="quran-content"></div>
+    <div class="quran-frame">
+      <div class="quran-loading">جاري التحميل...</div>
+      <div class="quran-content"></div>
+    </div>
     <div class="quran-nav" style="display: none;">
       <button class="quran-prev" title="السابق">❮</button>
       <button class="quran-page-display"></button>
@@ -237,10 +246,13 @@ export class OpenQuranView extends HTMLElement {
     if (oldValue === newValue) return;
 
     switch (name) {
-      case "page":
-        this.currentPage = parseInt(newValue, 10) || 1;
+      case "page": {
+        const newPage = parseInt(newValue, 10) || 1;
+        if (newPage === this.currentPage) return;
+        this.currentPage = newPage;
         this.renderPage();
         break;
+      }
       case "mushaf-layout":
       case "width":
       case "height":
@@ -287,7 +299,7 @@ export class OpenQuranView extends HTMLElement {
   }
 
   private async initialize(): Promise<void> {
-    const width = parseInt(this.getAttribute("width") || "600", 10);
+    const maxWidth = parseInt(this.getAttribute("width") || "600", 10);
     const height = parseInt(this.getAttribute("height") || "850", 10);
     const theme = (this.getAttribute("theme") || "light") as "light" | "dark";
     const mushafLayout = this.getAttribute(
@@ -295,15 +307,19 @@ export class OpenQuranView extends HTMLElement {
     ) as MushafLayout | null;
     this.layout = mushafLayout || "hafs-v2";
 
-    this.calculator = createLayoutCalculator({
-      pageWidth: width,
-      pageHeight: height,
-    });
-
-    this.container.style.maxWidth = `${width}px`;
+    this.container.style.maxWidth = `${maxWidth}px`;
     this.container.style.width = "100%";
     this.container.style.height = `${height}px`;
     this.updateTheme(theme);
+
+    const renderedWidth =
+      Math.min(maxWidth, this.container.getBoundingClientRect().width) ||
+      maxWidth;
+
+    this.calculator = createLayoutCalculator({
+      pageWidth: renderedWidth,
+      pageHeight: height,
+    });
 
     await this.loadFont();
 
@@ -523,6 +539,7 @@ export class OpenQuranView extends HTMLElement {
     page = Math.max(1, Math.min(page, this.totalPages));
     if (page !== oldPage) {
       this.currentPage = page;
+      this.setAttribute("page", String(page));
       this.renderPage();
 
       this.dispatchEvent(

--- a/src/view/web/index.ts
+++ b/src/view/web/index.ts
@@ -9,6 +9,13 @@ import {
   type PageLayout,
 } from "../../core";
 
+export const CENTERED_PAGES_VERTICAL = [1, 2] as const;
+export const CENTERED_PAGES_HORIZONTAL = [1, 2, 602, 603, 604] as const;
+
+const CENTERED_PAGES_HORIZONTAL_SET = new Set<number>(
+  CENTERED_PAGES_HORIZONTAL,
+);
+
 const STYLES = `
   :host {
     display: block;
@@ -98,7 +105,7 @@ const STYLES = `
     display: flex;
     gap: 12px;
     align-items: center;
-    padding: 12px;
+    padding: 2px;
     border-radius: 50px;
     backdrop-filter: blur(10px);
   }
@@ -408,10 +415,6 @@ export class OpenQuranView extends HTMLElement {
   private async renderLayout(pageLayout: PageLayout): Promise<void> {
     this.content.innerHTML = "";
 
-    const CENTERED_PAGES_HORIZONTAL_SET = new Set<number>([
-      1, 2, 602, 603, 604,
-    ]);
-
     for (const line of pageLayout.lines) {
       const isCenteredLine =
         line.isCentered || CENTERED_PAGES_HORIZONTAL_SET.has(this.currentPage);
@@ -489,7 +492,7 @@ export class OpenQuranView extends HTMLElement {
           });
           wordEl.addEventListener("click", () => {
             this.dispatchEvent(
-              new CustomEvent("wordClick", {
+              new CustomEvent("wordclick", {
                 detail: {
                   id: word.id,
                   surahNumber: word.surahNumber,
@@ -523,8 +526,8 @@ export class OpenQuranView extends HTMLElement {
       this.renderPage();
 
       this.dispatchEvent(
-        new CustomEvent("pageChange", {
-          detail: page,
+        new CustomEvent("pagechange", {
+          detail: { page },
           bubbles: false,
           composed: true,
         }),


### PR DESCRIPTION
## Summary
Aligns the web view (`<open-quran-view>`) custom element with the React view (`OpenQuranView`) for consistent behavior and API:

- **Constants alignment**: Extract `CENTERED_PAGES_VERTICAL` and `CENTERED_PAGES_HORIZONTAL` as exported named constants matching the React view
- **Nav controls**: Align padding (`12px` → `2px`) to match React `NavigationControls`
- **Event names**: Use lowercase `pagechange` and `wordclick` (DOM convention) matching playground expectations
- **Event detail format**: `pagechange` now dispatches `{ page: number }` matching playground's expected format
- **Playground update**: Use `goToPage()` method and `page` property for cleaner API

## Test plan
- [x] All 25 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Playground updated to use improved API

Closes #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized navigation controls layout with reduced padding for improved visual presentation.

* **Improvements**
  * Enhanced page navigation API for better programmatic control.
  * Refined component sizing and container behavior for more consistent scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->